### PR TITLE
Add DACE opacity download methods

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -109,6 +109,8 @@ html_context = {
     "github_repo": "shone",
     "github_version": "main",
     "doc_path": "docs",
+    "display_github": True,
+    "conf_py_path": "docs/",
 }
 
 html_logo = "logo/logo.png"

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -28,16 +28,17 @@ extensions = [
     'sphinx.ext.todo',
     'sphinx.ext.coverage',
     'sphinx.ext.inheritance_diagram',
-    'sphinx.ext.viewcode',
     'sphinx.ext.napoleon',
     'sphinx.ext.doctest',
     'sphinx.ext.mathjax',
     'sphinx_automodapi.automodapi',
     'sphinx_automodapi.smart_resolver',
     'sphinx.ext.autosectionlabel',
-    "matplotlib.sphinxext.plot_directive",
-    "numpydoc",
+    'matplotlib.sphinxext.plot_directive',
+    'numpydoc',
+    'sphinx_github_style',
 ]
+
 
 # Add any paths that contain templates here, relative to this directory.
 # templates_path = ["_templates"]
@@ -132,3 +133,9 @@ htmlhelp_basename = project + 'doc'
 modindex_common_prefix = ["shone."]
 
 suppress_warnings = ['autosectionlabel.*']
+
+# Github links:
+
+linkcode_blob = "main"
+linkcode_link_text = "[GitHub]"
+

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -127,4 +127,6 @@ html_title = '{0}'.format(project)
 htmlhelp_basename = project + 'doc'
 
 # Prefixes that are ignored for sorting the Python module index
-modindex_common_prefix = ["fleck."]
+modindex_common_prefix = ["shone."]
+
+suppress_warnings = ['autosectionlabel.*']

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -9,5 +9,6 @@ Fast radiative transfer in JAX.
   :maxdepth: 2
 
   shone/installation.rst
+  shone/opacities.rst
   shone/dev.rst
-  shone/index.rst
+  shone/api.rst

--- a/docs/shone/api.rst
+++ b/docs/shone/api.rst
@@ -3,3 +3,5 @@ Reference/API
 *************
 
 .. automodapi:: shone.chemistry
+
+.. automodapi:: shone.opacity

--- a/docs/shone/opacities.rst
+++ b/docs/shone/opacities.rst
@@ -1,0 +1,56 @@
+.. _opacities:
+
+*********
+Opacities
+*********
+
+Downloading opacities
+---------------------
+
+Several helper methods are included in ``shone`` for downloading and archiving
+local copies of opacities stored on `DACE <https://dace.unige.ch/>`_ via
+the package ``dace-query``. Users must register for an API key to use ``dace-query``,
+see `their documentation for instructions
+<https://dace-query.readthedocs.io/en/latest/dace_introduction.html#authentication>`_.
+
+To download the opacities for an atom with :func:`~shone.opacity.download_atom`, specify
+the atom's name and charge, and optionally limit the pressure range (in log10 bars)
+and temperature range (in Kelvin):
+
+.. code-block:: python
+
+    from shone.opacity.dace import download_atom
+
+    download_atom(
+        atom='Na',
+        charge=0,
+        temperature_range=[2500, 2500]
+    )
+
+You may query for molecules by their common names (for the most common
+isotopologue) with :func:`~shone.opacity.download_molecule` like so:
+
+.. code-block:: python
+
+    from shone.opacity.dace import download_molecule
+
+    download_molecule(
+        molecule_name='H2O',
+        temperature_range=[2500, 2500],
+        pressure_range=[-6, -6]
+    )
+
+or for a specific isotopologue:
+
+.. code-block:: python
+
+    from shone.opacity.dace import download_molecule
+
+    download_molecule(
+        isotopologue='1H2-16O',
+        temperature_range=[2500, 2500],
+        pressure_range=[-6, -6]
+    )
+
+These methods download the opacity grids from DACE, and store them in a netCDF file
+in your home directory with the name ``.shone/``.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,8 @@ dependencies = [
     "jax[cpu]",
     "jaxoplanet",
     "specutils",
-    "periodictable"
+    "periodictable",
+    "dace-query",
 ]
 dynamic = ["version"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ dependencies = [
     "specutils",
     "periodictable",
     "dace-query",
+    "xarray",
 ]
 dynamic = ["version"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,7 @@ docs = [
     "matplotlib",
     "expecto",
     "sphinx-book-theme",
+    "sphinx-github-style",
 ]
 
 [project.urls]

--- a/shone/__init__.py
+++ b/shone/__init__.py
@@ -4,3 +4,4 @@ except ImportError:
     __version__ = ''
 
 from .chemistry import *  # noqa
+from .opacity import *  # noqa

--- a/shone/opacity/__init__.py
+++ b/shone/opacity/__init__.py
@@ -1,0 +1,1 @@
+from .dace import *  # noqa

--- a/shone/opacity/dace.py
+++ b/shone/opacity/dace.py
@@ -300,8 +300,20 @@ def download_molecule(
         For example, "1H2-16O" for water.
     molecule_name : str
         Common name for the molecule, for example: "H2O"
-    line_list : str
-        For example, "POKAZATEL" for water.
+    line_list : str, default is ``'first-found'``, optional
+        For example, "POKAZATEL" for water. By default, the first available
+        line list for this isotopologue is chosen.
+    temperature_range : tuple, optional
+        Tuple of integers specifying the min and max
+        temperature requested. Defaults to the full
+        range of available temperatures.
+    pressure_range : tuple, optional
+        Tuple of floags specifying the log base 10 of the
+        min and max pressure [bar] requested. Defaults to the full
+        range of available pressures.
+    version : float, optional
+        Version number of the line list in DACE. Defaults to the
+        latest version.
     """
     if molecule_name is not None:
         isotopologue = species_name_to_common_isotopologue_name(molecule_name)
@@ -364,8 +376,20 @@ def download_atom(atom, charge, line_list='first-found',
         For example, "Na" for sodium.
     charge : int
         For example, 0 for neutral.
-    line_list : str
-        For example, "Kurucz".
+    line_list : str, default is ``'first-found'``, optional
+        For example, "Kurucz". By default, the first available
+        line list for this atom/charge is chosen.
+    temperature_range : tuple, optional
+        Tuple of integers specifying the min and max
+        temperature requested. Defaults to the full
+        range of available temperatures.
+    pressure_range : tuple, optional
+        Tuple of floags specifying the log base 10 of the
+        min and max pressure [bar] requested. Defaults to the full
+        range of available pressures.
+    version : float, optional
+        Version number of the line list in DACE. Defaults to the
+        latest version.
     """
     available_line_lists = available_opacities.get_atomic_line_lists(atom)
 

--- a/shone/opacity/dace.py
+++ b/shone/opacity/dace.py
@@ -1,0 +1,310 @@
+from functools import cached_property
+import os
+import tarfile
+import shutil
+from glob import glob
+
+import numpy as np
+import xarray as xr
+from astropy.table import Table
+from dace_query.opacity import Molecule, Atom
+
+
+interp_kwargs = dict(
+    method='nearest',
+    kwargs=dict(fill_value="extrapolate")
+)
+
+__all__ = [
+    'download_molecule',
+    'download_atom'
+]
+
+
+class AvailableOpacities:
+    @cached_property
+    def atomic(self):
+        return get_atomic_database()
+
+    @cached_property
+    def molecular(self):
+        return get_molecular_database()
+
+    def get_atomic_database_entry(self, atom, charge, line_list):
+        table = self.atomic
+        return table[(
+            (table['atom'] == atom) &
+            (table['line_list'] == line_list) &
+            (table['charge'] == charge)
+        )]
+
+    def get_molecular_database_entry(self, isotopologue, line_list):
+        table = self.molecular
+        return table[(
+            (table['isotopologue'] == isotopologue) &
+            (table['line_list'] == line_list)
+        )]
+
+    def get_atomic_pT_range(self, atom, charge, line_list):
+        table = self.get_atomic_database_entry(atom, charge, line_list)
+        temperature_range = (
+            float(table['temp_min_k'][0]),
+            float(table['temp_max_k'][0])
+        )
+        pressure_range = (
+            float(table['pressure_min_exponent_b'][0]),
+            float(table['pressure_max_exponent_b'][0])
+        )
+        return temperature_range, pressure_range
+
+    def get_molecular_pT_range(self, isotopologue, line_list):
+        table = self.get_molecular_database_entry(isotopologue, line_list)
+        temperature_range = (
+            float(table['temp_min_k'][0]),
+            float(table['temp_max_k'][0])
+        )
+        pressure_range = (
+            float(table['pressure_min_exponent_b'][0]),
+            float(table['pressure_max_exponent_b'][0])
+        )
+        return temperature_range, pressure_range
+
+
+available_opacities = AvailableOpacities()
+
+
+def get_atomic_database():
+    db = Atom.query_database()
+    table = Table(db)
+    table.add_index('atom')
+    return table
+
+
+def get_molecular_database():
+    db = Molecule.query_database()
+    table = Table(db)
+    table.add_index('isotopologue')
+    return table
+
+
+def dace_download_molecule(
+    isotopologue='48Ti-16O',
+    line_list='Toto',
+    temperature_range=None,
+    pressure_range=None,
+    version=1
+):
+    os.makedirs('tmp', exist_ok=True)
+    archive_name = isotopologue + '__' + line_list + '.tar.gz'
+    Molecule.download(
+        isotopologue,
+        line_list,
+        float(version),
+        temperature_range,
+        pressure_range,
+        output_directory='tmp',
+        output_filename=archive_name
+    )
+
+    return os.path.join('tmp', archive_name)
+
+
+def dace_download_atom(
+    element='Na',
+    charge=0,
+    line_list='Kurucz',
+    temperature_range=None,
+    pressure_range=None,
+    version=1
+):
+    os.makedirs('tmp', exist_ok=True)
+    archive_name = element + '__' + line_list + '.tar.gz'
+    Atom.download(
+        element, charge,
+        line_list, float(version),
+        temperature_range,
+        pressure_range,
+        output_directory='tmp',
+        output_filename=archive_name
+    )
+    return os.path.join('tmp', archive_name)
+
+
+def untar_bin_files(archive_name):
+    def bin_files(members):
+        for tarinfo in members:
+            if os.path.splitext(tarinfo.name)[1] == ".bin":
+                yield tarinfo
+
+    with tarfile.open(archive_name, 'r:gz') as tar:
+        tar.extractall(path='tmp/.', members=bin_files(tar))
+
+
+def get_opacity_dir_path_molecule(isotopologue, linelist):
+    return glob(os.path.join('tmp', isotopologue + '__' + linelist + "*e2b"))[0]
+
+
+def get_opacity_dir_path_atom(linelist):
+    return glob(os.path.join('tmp', linelist + "*e2b"))[0]
+
+
+def opacity_dir_to_netcdf(opacity_dir, outpath):
+    temperature_grid = []
+    pressure_grid = []
+
+    for dirpath, dirnames, filenames in os.walk(opacity_dir):
+        for filename in filenames:
+            if not filename.endswith('.bin'):
+                continue
+
+            # Wavenumber points from range given in the file names
+            temperature = int(filename.split('_')[3])
+            sign = 1 if filename.split('_')[4][0] == 'p' else -1
+            pressure = 10 ** (sign * float(filename.split('_')[4][1:].split('.')[0]) / 100)
+
+            wl_start = int(filename.split('_')[1])
+            wl_end = int(filename.split('_')[2])
+            wlen = np.arange(wl_start, wl_end, 0.01)
+
+            # Convert to micron
+            wavelength = 1 / wlen / 1e-4
+
+            unique_wavelengths = wavelength[1:][::-1]
+            temperature_grid.append(temperature)
+            pressure_grid.append(pressure)
+
+    tgrid = np.sort(list(set(temperature_grid)))
+    pgrid = np.sort(list(set(pressure_grid)))
+
+    if len(pgrid) == 1:
+        extrapolate_pgrid = True
+        pgrid = np.concatenate([pgrid, 10 ** (-1 * np.log10(pgrid))])
+    else:
+        extrapolate_pgrid = False
+
+    opacity_grid = np.zeros(
+        (len(tgrid), len(pgrid), len(unique_wavelengths)), dtype='float32'
+    )
+
+    for dirpath, dirnames, filenames in os.walk(opacity_dir):
+        for filename in filenames:
+            if not filename.endswith('.bin'):
+                continue
+
+            opacity = np.fromfile(
+                os.path.join(dirpath, filename), dtype=np.float32
+            )[1:][::-1]
+
+            # Wavenumber points from range given in the file names
+            temperature = int(filename.split('_')[3])
+            sign = 1 if filename.split('_')[4][0] == 'p' else -1
+            pressure = 10 ** (sign * float(filename.split('_')[4][1:].split('.')[0]) / 100)
+
+            temperature_ind = np.argmin(np.abs(tgrid - temperature))
+            pressure_ind = np.argmin(np.abs(pgrid - pressure))
+
+            opacity_grid[temperature_ind, pressure_ind, :] = opacity
+
+    if extrapolate_pgrid:
+        for dirpath, dirnames, filenames in os.walk(opacity_dir):
+            for filename in filenames:
+                opacity = np.fromfile(
+                    os.path.join(dirpath, filename), dtype=np.float32
+                )[1:][::-1]
+
+                # Wavenumber points from range given in the file names
+                temperature = int(filename.split('_')[3])
+                # *Flip the sign for the extrapolated grid point in pressure*
+                sign = -1 if filename.split('_')[4][0] == 'p' else 1
+                pressure = 10 ** (sign * float(filename.split('_')[4][1:].split('.')[0]) / 100)
+
+                temperature_ind = np.argmin(np.abs(tgrid - temperature))
+                pressure_ind = np.argmin(np.abs(pgrid - pressure))
+
+                opacity_grid[temperature_ind, pressure_ind, :] = opacity
+
+    ds = xr.Dataset(
+        data_vars=dict(
+            opacity=(["temperature", "pressure", "wavelength"],
+                     opacity_grid)
+        ),
+        coords=dict(
+            temperature=(["temperature"], tgrid),
+            pressure=(["pressure"], pgrid),
+            wavelength=unique_wavelengths
+        )
+    )
+
+    if not os.path.exists(os.path.dirname(outpath)):
+        os.makedirs(os.path.dirname(outpath), exist_ok=True)
+
+    ds.to_netcdf(outpath if outpath.endswith(".nc") else outpath + '.nc',
+                 encoding={'opacity': {'dtype': 'float32'}})
+
+
+def clean_up(bin_dir, archive_name):
+    os.remove(archive_name)
+    shutil.rmtree(bin_dir)
+
+
+def download_molecule(isotopologue, line_list):
+    """
+    Download molecular opacity data from DACE.
+
+    .. warning::
+        This generates *very* large files. Only run this
+        method if you have ~6 GB available per molecule.
+
+    Parameters
+    ----------
+    isotopologue : str
+        For example, "1H2-16O" for water.
+    line_list : str
+        For example, "POKAZATEL" for water.
+    """
+    temperature_range, pressure_range = available_opacities.get_molecular_pT_range(isotopologue, line_list)
+    archive_name = dace_download_molecule(isotopologue, line_list, temperature_range, pressure_range)
+    untar_bin_files(archive_name)
+    bin_dir = get_opacity_dir_path_molecule(
+        isotopologue, line_list
+    )
+
+    nc_path = os.path.join(
+        os.path.expanduser('~'),
+        '.shone',
+        isotopologue + '__' + line_list + '.nc'
+    )
+    opacity_dir_to_netcdf(bin_dir, nc_path)
+    clean_up(bin_dir, archive_name)
+
+
+def download_atom(atom, charge, line_list):
+    """
+    Download atomic opacity data from DACE.
+
+    .. warning::
+        This generates *very* large files. Only run this
+        method if you have ~6 GB available per molecule.
+
+    Parameters
+    ----------
+    atom : str
+        For example, "Na" for sodium.
+    charge : int
+        For example, 0 for neutral.
+    line_list : str
+        For example, "Kurucz".
+    """
+    temperature_range, pressure_range = available_opacities.get_atomic_pT_range(atom, charge, line_list)
+
+    archive_name = dace_download_atom(atom, charge, line_list, temperature_range, pressure_range)
+    untar_bin_files(archive_name)
+    bin_dir = get_opacity_dir_path_atom(line_list)
+
+    nc_path = os.path.join(
+        os.path.expanduser('~'),
+        '.shone',
+        atom + '_' + str(int(charge)) + '__' + line_list + '.nc'
+    )
+    opacity_dir_to_netcdf(bin_dir, nc_path)
+    clean_up(bin_dir, archive_name)

--- a/shone/opacity/dace.py
+++ b/shone/opacity/dace.py
@@ -10,6 +10,7 @@ import xarray as xr
 from astropy.table import Table
 from dace_query.opacity import Molecule, Atom
 
+from ..chemistry import species_name_to_common_isotopologue_name
 
 interp_kwargs = dict(
     method='nearest',
@@ -252,7 +253,13 @@ def clean_up(bin_dir, archive_name):
     shutil.rmtree(bin_dir)
 
 
-def download_molecule(isotopologue, line_list, temperature_range=None, pressure_range=None):
+def download_molecule(
+    isotopologue=None,
+    molecule_name=None,
+    line_list=None,
+    temperature_range=None,
+    pressure_range=None
+):
     """
     Download molecular opacity data from DACE.
 
@@ -264,9 +271,14 @@ def download_molecule(isotopologue, line_list, temperature_range=None, pressure_
     ----------
     isotopologue : str
         For example, "1H2-16O" for water.
+    molecule_name : str
+        Common name for the molecule, for example: "H2O"
     line_list : str
         For example, "POKAZATEL" for water.
     """
+    if molecule_name is not None:
+        isotopologue = species_name_to_common_isotopologue_name(molecule_name)
+
     if temperature_range is None or pressure_range is None:
         dace_temp_range, dace_press_range = available_opacities.get_molecular_pT_range(
             isotopologue, line_list


### PR DESCRIPTION
Adding dependency on [dace-query](https://dace-query.readthedocs.io/en/latest/index.html), and adding lots of local methods for a more user-friendly interface for DACE.

Downloads from DACE require a DACE API key, which you can get following [these instructions](https://dace-query.readthedocs.io/en/latest/dace_introduction.html#authentication).

After you have dace-query configured, you can download one grid-point from the opacity tables for sodium and TiO like so:
```python
from shone.opacity.dace import download_atom, download_molecule

# if you don't specify a temperature range or pressure
# range, the full range will be retrieved:
download_atom(
    atom='Na', 
    charge=0, 
    line_list='Kurucz', 
    temperature_range=[2500, 2500]
)

download_molecule(
    isotopologue='48Ti-16O', 
    line_list='Toto', 
    temperature_range=[50, 50], 
    pressure_range=[-6.0, -6.0]
)
```