### PR TITLE
Adding chemistry name helpers

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -10,3 +10,4 @@ Fast radiative transfer in JAX.
 
   shone/installation.rst
   shone/dev.rst
+  shone/index.rst

--- a/docs/shone/index.rst
+++ b/docs/shone/index.rst
@@ -1,0 +1,5 @@
+*************
+Reference/API
+*************
+
+.. automodapi:: shone.chemistry

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ dependencies = [
     "jax[cpu]",
     "jaxoplanet",
     "specutils",
+    "periodictable"
 ]
 dynamic = ["version"]
 

--- a/shone/__init__.py
+++ b/shone/__init__.py
@@ -3,4 +3,4 @@ try:
 except ImportError:
     __version__ = ''
 
-__all__ = []
+from .chemistry import *  # noqa

--- a/shone/chemistry.py
+++ b/shone/chemistry.py
@@ -1,0 +1,152 @@
+import re
+import numpy as np
+import astropy.units as u
+from periodictable import elements
+
+
+__all__ = [
+    'isotopologue_to_species',
+    'isotopologue_to_mass',
+    'species_name_to_fastchem_name',
+    'species_name_to_common_isotopologue_name'
+]
+
+
+def isotopologue_to_species(isotopologue):
+    """
+    Convert isotopologue name to common species name.
+
+    Example: Take 1H2-16O and turn it to H2O, or take 48Ti-16O and turn it to TiO.
+
+    Parameters
+    ----------
+    isotopologue : str
+        Isotopologue name, like "1H2-16O".
+
+    Returns
+    -------
+    common_name : str
+        Common name, like "H2O".
+    """
+    species = ""
+    for element in isotopologue.split('-'):
+        for s in re.findall(r'\D+\d*', element):
+            species += ''.join(s)
+    return species if len(species) > 0 else isotopologue
+
+
+def isotopologue_to_mass(isotopologue):
+    """
+    Find the total atomic mass for ``isotopologue``.
+
+    Example: take 1H2-16O and turn it to 18, or take 48Ti-16O and turn it to 64.
+
+    Parameters
+    ----------
+    isotopologue : str
+        Isotopologue name, like "1H2-16O".
+
+    Returns
+    -------
+    total_mass : astropy.units.Quantity
+        Total atomic mass, like 18 AMU.
+    """
+    mass = 0
+    for element in isotopologue.split('-'):
+        multiples = list(filter(lambda x: len(x) > 0, re.split(r'\D', element)))
+        if len(multiples) > 1:
+            species_mass, multiplier = multiples
+            mass += float(multiplier) * float(species_mass)
+        elif len(multiples) == 1:
+            mass += float(multiples[0])
+    return (mass if mass != 0 else getattr(elements, isotopologue).mass) * u.u
+
+
+def species_name_to_fastchem_name(species, return_mass=False):
+    """
+    Convert generic species name, like "H2O" or "ClAlF2", to
+    Hill notation for FastChem, like "H2O1" or "Al1Cl1F2".
+
+    Optionally, return the total mass of the species by summing the masses of its components.
+
+    Parameters
+    ----------
+    species : str
+        Generic name, like "H2O".
+
+    Returns
+    -------
+    hill_name : str
+        Name in Hill notation, like "H2O1".
+    """
+    atoms = np.array(list(filter(
+        lambda x: len(x) > 0, re.split(r"(?<=[a-z])|(?=[A-Z])|\d", species)
+    )))
+
+    multipliers = np.array([
+        int(x) if len(x) > 0 else 1 for x in re.split(r'\D', species)
+    ])
+    lens = [len(''.join(atom)) for atom in atoms]
+    multipliers_skipped = np.array([multipliers[cs] for cs in np.cumsum(lens)])
+
+    order = np.argsort(atoms)
+
+    correct_notation = ''.join([
+        a + str(m) for a, m in zip(atoms[order], multipliers_skipped[order])
+    ])
+
+    # If single atom, give only the name of the atom:
+    if len(correct_notation) == 2 and correct_notation.endswith('1'):
+        correct_notation = correct_notation[0]
+    elif len(correct_notation) == 3 and correct_notation.endswith('1'):
+        correct_notation = correct_notation[:2]
+
+    if return_mass:
+        # Optionally return mass of species
+        mass = 0
+        for atom, mult in zip(atoms, multipliers_skipped):
+            mass += getattr(elements, atom).mass * mult
+
+        return correct_notation, mass
+    return correct_notation
+
+
+def species_name_to_common_isotopologue_name(species):
+    """
+    Convert generic species name, like "H2O", to isotopologue name like "1H2-16O".
+
+    Parameters
+    ----------
+    species : str
+        Generic name, like "H2O".
+
+    Returns
+    -------
+    isotopologue_name : str
+        Isotopologue name, like "1H2-16O".
+    """
+    atoms = np.array(list(filter(
+        lambda x: len(x) > 0, re.split(r"(?<=[a-z])|(?=[A-Z])|\d", species)
+    )))
+
+    multipliers = np.array([
+        int(x) if len(x) > 0 else 1 for x in re.split(r'\D', species)
+    ])
+    lens = [len(''.join(atom)) for atom in atoms]
+    multipliers_skipped = np.array([multipliers[cs] for cs in np.cumsum(lens)])
+
+    masses = np.array([
+        round(getattr(elements, atom).mass) for atom, mult in zip(atoms, multipliers_skipped)
+    ])
+
+    if len(atoms) > 1:
+        correct_notation = '-'.join([
+            str(mass) + a + (str(mult) if mult > 1 else '')
+            for a, mult, mass in zip(atoms, multipliers_skipped, masses)
+        ])
+
+    # If single atom, give only the name of the atom:
+    else:
+        correct_notation = atoms[0]
+
+    return correct_notation

--- a/shone/tests/test_chemistry.py
+++ b/shone/tests/test_chemistry.py
@@ -1,0 +1,48 @@
+import pytest
+
+from ..chemistry import (
+    species_name_to_fastchem_name, isotopologue_to_species,
+    species_name_to_common_isotopologue_name
+)
+
+
+@pytest.mark.parametrize("isotopologue_name, species_name", (
+    zip(['1H2-16O', 'Na', 'K', '48Ti-16O'], ["H2O", "Na", "K", "TiO"])
+),)
+def test_chemical_names_manipulation_0(isotopologue_name, species_name):
+    # Test conversion of isotopologue name, like an opacity file with "1H2-16O"
+    # to what I'll call the common "species name" like H2O
+    assert isotopologue_to_species(isotopologue_name) == species_name
+
+
+@pytest.mark.parametrize("species_name, fastchem_name", (
+    zip(['H2O', 'TiO', 'VO', 'Na', 'K', 'CO', 'CrH',
+         'CF4O', 'Al2Cl6', 'AlNaF4', 'ClAlF2'],
+        ['H2O1', 'O1Ti1', 'O1V1', 'Na', 'K', 'C1O1', 'Cr1H1',
+         'C1F4O1', 'Al2Cl6', 'Al1F4Na1', 'Al1Cl1F2'])
+),)
+def test_chemical_names_manipulation_1(species_name, fastchem_name):
+    # Test conversion of common species name to a fastchem name which can
+    # be called in fastchem.getSpeciesIndex(fastchem_name)
+    assert species_name_to_fastchem_name(species_name) == fastchem_name
+
+
+@pytest.mark.parametrize("species_name, iso_name", (
+    zip(['H2O', 'TiO', 'VO', 'Na', 'K', 'CO', 'CrH',
+         'CF4O', 'Al2Cl6', 'AlClF2'],
+        ['1H2-16O', '48Ti-16O', '51V-16O', 'Na', 'K', '12C-16O', '52Cr-1H',
+         '12C-19F4-16O', '27Al2-35Cl6', '27Al-35Cl-19F2'])
+),)
+def test_chemical_names_manipulation_2(species_name, iso_name):
+    # Test conversion of common species name to a isotopologue name which can
+    # be used as a key in the opacities dictionary
+    assert species_name_to_common_isotopologue_name(species_name) == iso_name
+
+
+@pytest.mark.parametrize("iso_name", (
+    ['1H2-16O', '48Ti-16O', '51V-16O', 'Na', 'K', '12C-16O', '52Cr-1H',
+     '12C-19F4-16O', '27Al2-35Cl6', '27Al-35Cl-19F2']
+),)
+def test_chemical_names_manipulation_3(iso_name):
+    # Test round-trip conversion of isotopologue name, to species name, and back
+    assert species_name_to_common_isotopologue_name(isotopologue_to_species(iso_name)) == iso_name


### PR DESCRIPTION
These helper methods allow a user to enter a common atomic/molecular species name or an isotopologue name, and convert it to other naming conventions or find masses for atoms and molecules. These methods are useful for accepting a wide range of user input when specifying species for opacities and chemistry calculations.