### PR TITLE
Build grids of pre-computed mixing ratios with FastChem

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -30,7 +30,6 @@ extensions = [
     'sphinx.ext.intersphinx',
     'sphinx.ext.todo',
     'sphinx.ext.coverage',
-    # 'sphinx.ext.inheritance_diagram',
     'sphinx.ext.napoleon',
     'sphinx.ext.doctest',
     'sphinx.ext.mathjax',

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -30,7 +30,7 @@ extensions = [
     'sphinx.ext.intersphinx',
     'sphinx.ext.todo',
     'sphinx.ext.coverage',
-    'sphinx.ext.inheritance_diagram',
+    # 'sphinx.ext.inheritance_diagram',
     'sphinx.ext.napoleon',
     'sphinx.ext.doctest',
     'sphinx.ext.mathjax',

--- a/docs/shone/api.rst
+++ b/docs/shone/api.rst
@@ -2,10 +2,14 @@
 Reference/API
 *************
 
-.. automodapi:: shone.chemistry
-    :no-inheritance-diagram:
 
 .. automodapi:: shone.opacity
+    :no-inheritance-diagram:
+
+.. automodapi:: shone.chemistry.fastchem
+    :no-inheritance-diagram:
+
+.. automodapi:: shone.chemistry.translate
     :no-inheritance-diagram:
 
 .. automodapi:: shone.transmission

--- a/docs/shone/api.rst
+++ b/docs/shone/api.rst
@@ -3,9 +3,13 @@ Reference/API
 *************
 
 .. automodapi:: shone.chemistry
+    :no-inheritance-diagram:
 
 .. automodapi:: shone.opacity
+    :no-inheritance-diagram:
 
 .. automodapi:: shone.transmission
+    :no-inheritance-diagram:
 
 .. automodapi:: shone.spectrum
+    :no-inheritance-diagram:

--- a/docs/shone/api.rst
+++ b/docs/shone/api.rst
@@ -7,3 +7,5 @@ Reference/API
 .. automodapi:: shone.opacity
 
 .. automodapi:: shone.transmission
+
+.. automodapi:: shone.spectrum

--- a/docs/shone/examples.rst
+++ b/docs/shone/examples.rst
@@ -8,3 +8,4 @@ Examples
 
   examples/opacities.rst
   examples/simple_transmission.rst
+  examples/chemistry.rst

--- a/docs/shone/examples/chemistry.rst
+++ b/docs/shone/examples/chemistry.rst
@@ -119,7 +119,7 @@ species:
 
     # lookup the column index for O2 in the fastchem VMR matrix:
     idx = species_table.loc['O2']['index']
-    vmr_O2 = vmr[: idx]
+    vmr_O2 = chem.vmr()[: idx]
 
 We can plot the VMRs of several species as a function of pressure like so:
 
@@ -132,7 +132,7 @@ We can plot the VMRs of several species as a function of pressure like so:
     names = species_table.loc[species]['name']
 
     ax = plt.gca()
-    ax.loglog(vmr[:, indices], pressure, label=names)
+    ax.loglog(chem.vmr()[:, indices], pressure, label=names)
     ax.legend(loc='lower left')
     ax.invert_yaxis()
     ax.set(
@@ -200,7 +200,7 @@ Build a grid
 As the name suggests, the FastChem is fast! That said, computing it millions of times
 during Monte Carlo sampling may not be the best use of your time for species with mixing
 ratios that vary smoothly with temperature, pressure, M/H, and C/O. We have included a
-convenience function called `~shone.chemistry.build_fastchem_grid` that runs FastChem in
+convenience function called `~shone.chemistry.fastchem.build_fastchem_grid` that runs FastChem in
 a loop over these four dimensions to create a ~100 MB grid of abundances for each species
 in less than a minute on a laptop:
 
@@ -208,10 +208,11 @@ in less than a minute on a laptop:
 
     from shone.chemistry import build_fastchem_grid
 
-    chem_grid = build_fastchem_grid()
+    build_fastchem_grid()  # returns a chemistry grid and saves it to disk
 
 The grid is saved to your `~/.shone` directory and can be interpolated during sampling to
-use *approximate* FastChem mixing ratios.
+use *approximate* FastChem mixing ratios. The default limits for each dimension are enumerated
+in the documentation for `~shone.chemistry.fastchem.build_fastchem_grid`.
 
 Interpolate from the grid
 +++++++++++++++++++++++++

--- a/docs/shone/examples/chemistry.rst
+++ b/docs/shone/examples/chemistry.rst
@@ -64,9 +64,9 @@ Returns a table like this:
 .. raw:: html
 
     <br />
-    <table>
+    <table style="width:75%">
       <thead>
-        <tr>
+        <tr style="text-align: left;">
           <th></th>
           <th>index</th>
           <th>name</th>
@@ -191,8 +191,11 @@ we must multiply the opacity :math:`\kappa` by the mass density of the species :
 [:math:`{\rm g~cm}^{-3}`].
 
 
-Precompute a FastChem grid
---------------------------
+Precompute FastChem on grid
+---------------------------
+
+Build a grid
+++++++++++++
 
 As the name suggests, the FastChem is fast! That said, computing it millions of times
 during Monte Carlo sampling may not be the best use of your time for species with mixing
@@ -209,3 +212,98 @@ in less than a minute on a laptop:
 
 The grid is saved to your `~/.shone` directory and can be interpolated during sampling to
 use *approximate* FastChem mixing ratios.
+
+Interpolate from the grid
++++++++++++++++++++++++++
+
+Now let's print a table of volume mixing ratios for the first five species:
+
+.. code-block:: python
+
+    from shone.chemistry import get_fastchem_interpolator, fastchem_species_table
+    from astropy.table import Table
+
+    # load the jitted chemistry interpolator:
+    interp_chem = get_fastchem_interpolator()
+
+    # load a table listing all species:
+    species_table = fastchem_species_table()
+
+    temperature = 2300  # [K]
+    pressure = 1e-3  # [bar]
+    log_m_to_h = 0.3
+    log_c_to_o = -0.2
+
+    # interpolate on all four axes, return VMR for
+    vmr = interp_chem(temperature, pressure, log_m_to_h, log_c_to_o)
+
+    # add a column to the table of species with the VMRs:
+    species_table['vmr'] = vmr[0]
+
+    print(species_table[:5])
+
+.. raw:: html
+
+    <table style="width:75%">
+      <thead>
+        <tr style="text-align: left;">
+          <th></th>
+          <th>index</th>
+          <th>name</th>
+          <th>weight</th>
+          <th>type</th>
+          <th>vmr</th>
+        </tr>
+        <tr>
+          <th>symbol</th>
+          <th></th>
+          <th></th>
+          <th></th>
+          <th></th>
+          <th></th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <th>e-</th>
+          <td>0</td>
+          <td>Electron</td>
+          <td>0.00055</td>
+          <td>element</td>
+          <td>1.9e-06</td>
+        </tr>
+        <tr>
+          <th>Al</th>
+          <td>1</td>
+          <td>Aluminium</td>
+          <td>27</td>
+          <td>element</td>
+          <td>8.9e-06</td>
+        </tr>
+        <tr>
+          <th>Ar</th>
+          <td>2</td>
+          <td>Argon</td>
+          <td>40</td>
+          <td>element</td>
+          <td>8.1e-06</td>
+        </tr>
+        <tr>
+          <th>C</th>
+          <td>3</td>
+          <td>Carbon</td>
+          <td>12</td>
+          <td>element</td>
+          <td>2.5e-12</td>
+        </tr>
+        <tr>
+          <th>Ca</th>
+          <td>4</td>
+          <td>Calcium</td>
+          <td>40</td>
+          <td>element</td>
+          <td>6.6e-06</td>
+        </tr>
+      </tbody>
+    </table>
+

--- a/docs/shone/examples/chemistry.rst
+++ b/docs/shone/examples/chemistry.rst
@@ -1,0 +1,211 @@
+.. _chemistry:
+
+Chemistry
+=========
+
+FastChem Wrapper
+----------------
+
+We can compute mixing ratios for species in atmospheres with equilibrium chemistry
+using `FastChem <https://github.com/exoclime/FastChem>`_. For your convenience, we
+wrap the FastChem python API in the class `~shone.chemistry.FastchemWrapper`, which
+makes it easy to compute the quantities needed in this package.
+
+Let's construct a atmospheric structure (temperature-pressure curve):
+
+.. code-block:: python
+
+    import numpy as np
+
+    pressure = np.geomspace(1e-6, 10, 15)  # [bar]
+    temperature = 2300 * (pressure / 0.1) ** 0.1  # [K]
+
+.. plot::
+
+    import numpy as np
+    import matplotlib.pyplot as plt
+
+    pressure = np.geomspace(1e-6, 10, 15)  # [bar]
+    temperature = 2300 * (np.geomspace(1e-6, 10, pressure.size) / 0.1) ** 0.1  # [K]
+
+    ax = plt.gca()
+    ax.semilogy(temperature, pressure)
+    ax.invert_yaxis()
+    ax.set(
+        xlabel='Temperature [K]',
+        ylabel='Pressure [bar]'
+    )
+
+Radiative transfer calculations require the mixing ratio of each atmospheric species, which are
+functions of temperature, pressure, atmospheric metallicity, and C/O ratio. We specify these
+parameters like so:
+
+.. code-block:: python
+
+    from shone.chemistry import FastchemWrapper
+
+    chem = FastchemWrapper(
+        temperature, pressure,
+        # these are in linear (not log) units:
+        metallicity=1,  # M/H
+        c_to_o_ratio=1  # C/O
+    )
+
+The wrapper can enumerate the names, symbols, weights, and indices for each
+species with `~shone.chemistry.FastchemWrapper.get_species`:
+
+.. code-block:: python
+
+    species_table = chem.get_species()
+    print(species_table[:3])  # first three species
+
+Returns a table like this:
+
+.. raw:: html
+
+    <br />
+    <table>
+      <thead>
+        <tr>
+          <th></th>
+          <th>index</th>
+          <th>name</th>
+          <th>weight</th>
+          <th>type</th>
+        </tr>
+        <tr>
+          <th>symbol</th>
+          <th></th>
+          <th></th>
+          <th></th>
+          <th></th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <th>e-</th>
+          <td>0</td>
+          <td>Electron</td>
+          <td>0.000549</td>
+          <td>element</td>
+        </tr>
+        <tr>
+          <th>Al</th>
+          <td>1</td>
+          <td>Aluminium</td>
+          <td>26.981538</td>
+          <td>element</td>
+        </tr>
+        <tr>
+          <th>Ar</th>
+          <td>2</td>
+          <td>Argon</td>
+          <td>39.948000</td>
+          <td>element</td>
+        </tr>
+      </tbody>
+    </table>
+    <br />
+    <br />
+
+Volume mixing ratio
++++++++++++++++++++
+
+We compute the matrix of volume mixing ratios for all species with
+`~shone.chemistry.FastchemWrapper.vmr`, and index it for a particular
+species:
+
+.. code-block:: python
+
+    # lookup the column index for O2 in the fastchem VMR matrix:
+    idx = species_table.loc['O2']['index']
+    vmr_O2 = vmr[: idx]
+
+We can plot the VMRs of several species as a function of pressure like so:
+
+.. code-block:: python
+
+    import matplotlib.pyplot as plt
+
+    species = ['H2O1', 'O1Ti1', 'e-']
+    indices = species_table.loc[species]['index']
+    names = species_table.loc[species]['name']
+
+    ax = plt.gca()
+    ax.loglog(vmr[:, indices], pressure, label=names)
+    ax.legend(loc='lower left')
+    ax.invert_yaxis()
+    ax.set(
+        xlabel='Volume mixing ratio',
+        ylabel='Pressure [bar]'
+    )
+
+.. plot::
+
+    import numpy as np
+    import matplotlib.pyplot as plt
+
+    from shone.chemistry import FastchemWrapper
+
+    pressure = np.geomspace(1e-6, 10, 15)  # [bar]
+    temperature = 2300 * (pressure / 0.1) ** 0.1  # [K]
+
+    chem = FastchemWrapper(
+        temperature, pressure,
+        # these are in linear (not log) units:
+        metallicity=1,  # M/H
+        c_to_o_ratio=1  # C/O
+    )
+    species_table = chem.get_species()
+    vmr = chem.vmr()
+
+    species = ['H2O1', 'O1Ti1', 'e-']
+    indices = species_table.loc[species]['index']
+    names = species_table.loc[species]['name']
+
+    ax = plt.gca()
+    ax.loglog(vmr[:, indices], pressure, label=names)
+    ax.legend(loc='lower left')
+    ax.invert_yaxis()
+    ax.set(
+        xlabel='Volume mixing ratio',
+        ylabel='Pressure [bar]'
+    )
+
+Mass mixing ratio
++++++++++++++++++
+
+The mass mixing ratio (MMR) is equivalent to the volume mixing ratio multiplied
+by the mass of the species and divided by the mean molecular weight. Since
+mean molecular weight is often a free parameter in a real atmospheric retrieval, we
+can't return "one MMR" per FastChem run. So `~shone.chemistry.FastchemWrapper` has
+a method called `~shone.chemistry.FastchemWrapper.mmr_mmw` which returns the VMR
+multiplied by the molecular mass, which is equivalent to the MMR multiplied by
+the mean molecular weight. To convert this to mass mixing ratio, simply divide
+the result of `~shone.chemistry.FastchemWrapper.mmr_mmw` by the mean molecular weight.
+
+Opacity grids are often stored as cross sections per mass, usually written
+as :math:`\kappa` [:math:`{\rm cm}^2~{\rm g}^{-1}`]. To
+compute an extinction coefficient :math:`\alpha` [:math:`{\rm cm}^{-1}`],
+we must multiply the opacity :math:`\kappa` by the mass density of the species :math:`\rho`
+[:math:`{\rm g~cm}^{-3}`].
+
+
+Precompute a FastChem grid
+--------------------------
+
+As the name suggests, the FastChem is fast! That said, computing it millions of times
+during Monte Carlo sampling may not be the best use of your time for species with mixing
+ratios that vary smoothly with temperature, pressure, M/H, and C/O. We have included a
+convenience function called `~shone.chemistry.build_fastchem_grid` that runs FastChem in
+a loop over these four dimensions to create a ~100 MB grid of abundances for each species
+in less than a minute on a laptop:
+
+.. code-block:: python
+
+    from shone.chemistry import build_fastchem_grid
+
+    chem_grid = build_fastchem_grid()
+
+The grid is saved to your `~/.shone` directory and can be interpolated during sampling to
+use *approximate* FastChem mixing ratios.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ dependencies = [
     "xarray",
     "tensorflow-probability",
     "pyfastchem",
+    "tqdm"
 ]
 dynamic = ["version"]
 

--- a/shone/__init__.py
+++ b/shone/__init__.py
@@ -6,3 +6,4 @@ except ImportError:
 from .opacity import *  # noqa
 from .chemistry import *  # noqa
 from .transmission import *  # noqa
+from .spectrum import *  # noqa

--- a/shone/__init__.py
+++ b/shone/__init__.py
@@ -3,7 +3,7 @@ try:
 except ImportError:
     __version__ = ''
 
-from .opacity import *  # noqa
 from .chemistry import *  # noqa
+from .opacity import *  # noqa
 from .transmission import *  # noqa
 from .spectrum import *  # noqa

--- a/shone/chemistry/fastchem.py
+++ b/shone/chemistry/fastchem.py
@@ -246,13 +246,13 @@ def build_fastchem_grid(
     Parameters
     ----------
     temperature : array-like
-        Temperature grid.
+        Temperature grid. Default is roughly log-spaced from 300 to 6000 K.
     pressure : array-like
-        Pressure grid.
+        Pressure grid. Default is roughly log-spaced from 1e-8 to 10 bar.
     log_m_to_h : array-like
-        Metallicity grid.
+        Metallicity grid. Default is log-spaced from -1 to 3.
     log_c_to_o : array-like
-        C/O grid.
+        C/O grid. Default is log-spaced from -1 to 2.
     n_species : int
         Number of species in this FastChem computation.
 
@@ -267,7 +267,7 @@ def build_fastchem_grid(
     if pressure is None:
         pressure = round_in_log(np.geomspace(1e-8, 10, 20))
     if log_m_to_h is None:
-        log_m_to_h = np.linspace(-1, 2.5, 8)
+        log_m_to_h = np.linspace(-1, 3, 11)
     if log_c_to_o is None:
         log_c_to_o = np.linspace(-1, 2, 16)
 

--- a/shone/chemistry/fastchem.py
+++ b/shone/chemistry/fastchem.py
@@ -23,14 +23,17 @@ class FastchemWrapper:
 
     References
     ----------
-    .. [1] Stock, J. W., Kitzmann, D., Patzer, A. B. C., et al. 2018,
+    .. [1] `Stock, J. W., Kitzmann, D., Patzer, A. B. C., et al. 2018,
        Monthly Notices of the Royal Astronomical Society, 479,
-       865. doi:10.1093/mnras/sty1531
-    .. [2] Stock, J. W., Kitzmann, D., & Patzer, A. B. C. 2022,
+       865. <https://ui.adsabs.harvard.edu/abs/2018MNRAS.479..865S/abstract>`_
+       doi:10.1093/mnras/sty1531
+    .. [2] `Stock, J. W., Kitzmann, D., & Patzer, A. B. C. 2022,
        Monthly Notices of the Royal Astronomical Society, 517,
-       4070. doi:10.1093/mnras/stac2623
-    .. [3] Kitzmann, D., Stock, J. W., & Patzer, A. B. C. 2024, Monthly
+       4070. <https://ui.adsabs.harvard.edu/abs/2022MNRAS.517.4070S/abstract>`_
+       doi:10.1093/mnras/stac2623
+    .. [3] `Kitzmann, D., Stock, J. W., & Patzer, A. B. C. 2024, Monthly
        Notices of the Royal Astronomical Society, 527, 7263.
+       <https://ui.adsabs.harvard.edu/abs/2024MNRAS.527.7263K/abstract>`_
        doi:10.1093/mnras/stad3515
     .. [4] `FastChem on Github <https://github.com/exoclime/FastChem>`_.
     """

--- a/shone/chemistry/fastchem.py
+++ b/shone/chemistry/fastchem.py
@@ -1,13 +1,16 @@
+from functools import partial
 import os
 import numpy as np
 from tqdm.auto import tqdm
 import xarray as xr
+from jax import numpy as jnp, jit
 
 from astropy.constants import m_p, k_B
 from astropy.table import Table
 from pyfastchem import (
     FastChem, FastChemInput, FastChemOutput
 )
+from tensorflow_probability.substrates.jax.math import batch_interp_rectilinear_nd_grid as nd_interp
 
 from shone.config import shone_dir
 
@@ -18,7 +21,7 @@ k_B = k_B.cgs.value
 
 fastchem_grid_filename = 'fastchem_grid.nc'
 
-__all__ = ['FastchemWrapper', 'build_fastchem_grid']
+__all__ = ['FastchemWrapper', 'build_fastchem_grid', 'get_fastchem_interpolator']
 
 
 class FastchemWrapper:
@@ -211,8 +214,8 @@ class FastchemWrapper:
             for each species.
         """
         vmr = self.vmr()
-        weights = self.get_weights()
-        mmr_mmw = vmr * weights[None, :]
+        weights_amu = self.get_weights()
+        mmr_mmw = vmr * weights_amu[None, :]
 
         return mmr_mmw
 
@@ -268,7 +271,8 @@ def build_fastchem_grid(
         n_species
     )
 
-    results = np.empty(shape, dtype=np.float32)
+    results_mmr = np.empty(shape, dtype=np.float32)
+    results_vmr = np.empty(shape, dtype=np.float32)
     pressure2d, temperature2d = np.meshgrid(pressure, temperature)
 
     for i, log_mh in tqdm(
@@ -284,17 +288,19 @@ def build_fastchem_grid(
             )
 
             mmr_mmw = chem2d.mmr_mmw().reshape((*pressure2d.shape, n_species))
+            vmr = chem2d.vmr().reshape((*pressure2d.shape, n_species))
 
-            results[:, :, i, j, :] = mmr_mmw
+            results_mmr[:, :, i, j, :] = mmr_mmw
+            results_vmr[:, :, i, j, :] = vmr
 
     species_table = chem2d.get_species()
 
+    coord_names = "pressure temperature log_m_to_h log_c_to_o species".split()
+
     ds = xr.Dataset(
         data_vars=dict(
-            mmr_mmw=(
-                "pressure temperature log_m_to_h log_c_to_o species".split(),
-                results
-            )
+            mmr_mmw=(coord_names, results_mmr),
+            vmr=(coord_names, results_vmr)
         ),
         coords=dict(
             temperature=temperature,
@@ -308,3 +314,59 @@ def build_fastchem_grid(
 
     ds.to_netcdf(os.path.join(shone_dir, fastchem_grid_filename))
     return ds
+
+
+def get_fastchem_interpolator(path=None):
+    """
+    Return a jitted FastChem abundance interpolator.
+
+    Returns
+    -------
+    interp : function
+        A just-in-time compiled opacity interpolator.
+    """
+    if path is None:
+        path = os.path.join(shone_dir, fastchem_grid_filename)
+
+    with xr.open_dataset(path) as ds:
+        grid = ds.vmr
+
+    x_grid_points = (
+        jnp.float32(grid.pressure.to_numpy()),
+        jnp.float32(grid.temperature.to_numpy()),
+        jnp.float32(grid.log_m_to_h.to_numpy()),
+        jnp.float32(grid.log_c_to_o.to_numpy()),
+    )
+
+    @partial(jit, donate_argnames=('grid',))
+    def interp(
+        temperature, pressure, log_m_to_h, log_c_to_o,
+        grid=grid.to_numpy().astype(np.float32)
+    ):
+        """
+        Parameters
+        ----------
+        temperature : float
+            Temperature value.
+        pressure : float
+            Pressure value.
+        log_m_to_h : float
+            [M/H] value.
+        log_c_to_o : array-like
+            [C/O] value.
+        """
+        interp_point = jnp.column_stack([
+            pressure,
+            temperature,
+            log_m_to_h,
+            log_c_to_o,
+        ]).astype(jnp.float32)
+
+        return nd_interp(
+            interp_point,
+            x_grid_points,
+            grid,
+            axis=0
+        )
+
+    return interp

--- a/shone/config.py
+++ b/shone/config.py
@@ -1,0 +1,9 @@
+import os
+
+on_rtd = os.getenv('READTHEDOCS', False)
+
+shone_dir = os.path.expanduser(os.path.join("~", ".shone"))
+
+if on_rtd:
+    # use a temporary directory on readthedocs:
+    shone_dir = os.path.abspath('./.')

--- a/shone/opacity/dace.py
+++ b/shone/opacity/dace.py
@@ -21,7 +21,8 @@ interp_kwargs = dict(
 
 __all__ = [
     'download_molecule',
-    'download_atom'
+    'download_atom',
+    'available_opacities'
 ]
 
 
@@ -337,11 +338,13 @@ def download_molecule(
     version=None,
 ):
     """
-    Download molecular opacity data from DACE.
+    Download molecular opacity data from DACE [1]_ [2]_.
+
+    These opacities were computed with HELIOS-K [3]_ [4]_ [5]_.
 
     .. warning::
         This generates *very* large files. Only run this
-        method if you have ~6 GB available per molecule.
+        method if you a few GB available per molecule.
 
     Parameters
     ----------
@@ -363,6 +366,20 @@ def download_molecule(
     version : float, optional
         Version number of the line list in DACE. Defaults to the
         latest version.
+
+    References
+    ----------
+    .. [1] `Buchschacher, N. & Alesina, F. 2019, Astronomical Data Analysis
+           Software and Systems XXVI, 521, 757
+           <https://ui.adsabs.harvard.edu/abs/2019ASPC..521..757B/abstract>`_
+    .. [2] `DACE webpage <https://dace.unige.ch/>`_
+    .. [3] `Grimm, S. L. & Heng, K. 2015, The Astrophysical Journal, 808, 182.
+           <https://ui.adsabs.harvard.edu/abs/2015ApJ...808..182G/abstract>`_
+           doi:10.1088/0004-637X/808/2/182
+    .. [4] `Grimm, S. L., Malik, M., Kitzmann, D., et al. 2021, The Astrophysical
+           Journal Supplement Series, 253, 30. doi:10.3847/1538-4365/abd773
+           <https://ui.adsabs.harvard.edu/abs/2021ApJS..253...30G/abstract>`_
+    .. [5] `HELIOS-K on GitHub <https://github.com/exoclime/helios-k>`_
     """
     if molecule_name is not None:
         isotopologue = species_name_to_common_isotopologue_name(molecule_name)
@@ -488,11 +505,13 @@ def parse_nc_path_atom(filename):
 def download_atom(atom, charge, line_list='first-found',
                   temperature_range=None, pressure_range=None, version=None):
     """
-    Download atomic opacity data from DACE.
+    Download atomic opacity data from DACE [1]_ [2]_.
+
+    These opacities were computed with HELIOS-K [3]_ [4]_ [5]_.
 
     .. warning::
         This generates *very* large files. Only run this
-        method if you have ~6 GB available per molecule.
+        method if you have a few GB available per atom.
 
     Parameters
     ----------
@@ -514,6 +533,20 @@ def download_atom(atom, charge, line_list='first-found',
     version : float, optional
         Version number of the line list in DACE. Defaults to the
         latest version.
+
+    References
+    ----------
+    .. [1] `Buchschacher, N. & Alesina, F. 2019, Astronomical Data Analysis
+           Software and Systems XXVI, 521, 757
+           <https://ui.adsabs.harvard.edu/abs/2019ASPC..521..757B/abstract>`_
+    .. [2] `DACE webpage <https://dace.unige.ch/>`_
+    .. [3] `Grimm, S. L. & Heng, K. 2015, The Astrophysical Journal, 808, 182.
+           <https://ui.adsabs.harvard.edu/abs/2015ApJ...808..182G/abstract>`_
+           doi:10.1088/0004-637X/808/2/182
+    .. [4] `Grimm, S. L., Malik, M., Kitzmann, D., et al. 2021, The Astrophysical
+           Journal Supplement Series, 253, 30. doi:10.3847/1538-4365/abd773
+           <https://ui.adsabs.harvard.edu/abs/2021ApJS..253...30G/abstract>`_
+    .. [5] `HELIOS-K on GitHub <https://github.com/exoclime/helios-k>`_
     """
     available_line_lists = available_opacities.get_atomic_line_lists(atom)
 

--- a/shone/opacity/dace.py
+++ b/shone/opacity/dace.py
@@ -457,10 +457,13 @@ def create_nc_path_molecule(
 
 def parse_nc_path_molecule(filename):
     basename = os.path.basename(filename).split('.nc')[0]
-    (
-        isotopologue, line_list, temp_min, temp_max,
-        press_min, press_max, version
-    ) = basename.split('_')
+    try:
+        (
+            isotopologue, line_list, temp_min, temp_max,
+            press_min, press_max, version
+        ) = basename.split('_')
+    except ValueError as e:
+        raise ValueError(f"failed to parse {filename} with error: {e}")
 
     temperature_range = [float(temp_min), float(temp_max)]
     pressure_range = [float(press_min), float(press_max)]

--- a/shone/opacity/io.py
+++ b/shone/opacity/io.py
@@ -9,18 +9,10 @@ from astropy.table import Table
 from jax import numpy as jnp, jit
 from tensorflow_probability.substrates.jax.math import batch_interp_rectilinear_nd_grid as nd_interp
 
+from shone.config import shone_dir
 from shone.chemistry import isotopologue_to_species
 
 __all__ = ['Opacity', 'generate_synthetic_opacity']
-
-
-on_rtd = os.getenv('READTHEDOCS', False)
-
-shone_dir = os.path.expanduser(os.path.join("~", ".shone"))
-
-if on_rtd:
-    # use a temporary directory on readthedocs:
-    shone_dir = os.path.abspath('./.')
 
 
 class Opacity:
@@ -134,7 +126,9 @@ class Opacity:
                     version
                 ) = parse_nc_path_molecule(file_name)
             else:
+                # if name doesn't match expected pattern, skip it:
                 continue
+
             species = isotopologue or atom
 
             table_contents["name"].append(isotopologue_to_species(species))

--- a/shone/opacity/io.py
+++ b/shone/opacity/io.py
@@ -127,13 +127,14 @@ class Opacity:
                     temperature_range, pressure_range,
                     version
                 ) = parse_nc_path_atom(file_name)
-            else:
+            elif len(file_name.split('_')) == 7:
                 (
                     isotopologue, line_list,
                     temperature_range, pressure_range,
                     version
                 ) = parse_nc_path_molecule(file_name)
-
+            else:
+                continue
             species = isotopologue or atom
 
             table_contents["name"].append(isotopologue_to_species(species))

--- a/shone/spectrum.py
+++ b/shone/spectrum.py
@@ -1,0 +1,119 @@
+from functools import partial
+from jax import numpy as jnp, jit, lax
+
+
+__all__ = ['bin_spectrum']
+
+
+@jit
+def bin_centers_to_edges(wavelength):
+    """
+    For a vector of bin centers, estimate the bin edges and
+    bin widths.
+
+    Parameters
+    ----------
+    wavelength : array-like
+        Wavelengths at bin centers for a spectrum.
+
+    Returns
+    -------
+    edges : array-like
+        Wavelength bin edges.
+    widths : array-like
+        Wavelength bin widths.
+    """
+    edges_0 = jnp.array([wavelength[0] - (wavelength[1] - wavelength[0]) / 2])
+    widths_m1 = jnp.array([wavelength[-1] - wavelength[-2]])
+    edges_m1 = jnp.array([wavelength[-1] + (wavelength[-1] - wavelength[-2]) / 2])
+    edges_middle = (wavelength[1:] + wavelength[:-1]) / 2
+    edges = jnp.concatenate([edges_0, edges_middle, edges_m1])
+    widths = jnp.concatenate([edges[1:-1] - edges[:-2], widths_m1])
+
+    return edges, widths
+
+
+@jit
+def bin_spectrum(output_wavelength, input_wavelength, input_flux):
+    """
+    Bin a spectrum from one wavelength grid to another.
+
+    This function is a JAX implementation of SpectRes [1]_
+    from A. C. Carnall [2]_.
+
+    Parameters
+    ----------
+    output_wavelength : array−like
+        The target output grid of central wavelengths.
+    input_wavelength : array-like
+        The input grid of central wavelengths.
+    input_flux : array-like
+        The fluxes at each input wavelength.
+
+    Returns
+    -------
+    binned_spectrum : array-like
+        Spectrum binned to a different resolution.
+
+    References
+    ----------
+    .. [1] `SpectRes on GitHub <https://github.com/ACCarnall/SpectRes>`_.
+    .. [2]  Carnall, A. C. 2017, `arXiv:1705.05165 <https://arxiv.org/abs/1705.05165>`_.
+            doi:10.48550/arXiv.1705.05165
+    """
+    old_edges, old_widths = bin_centers_to_edges(input_wavelength)
+    new_edges, new_widths = bin_centers_to_edges(output_wavelength)
+
+    starts_stops = jnp.column_stack([new_edges[:-1], new_edges[1:]])
+    indices = jnp.searchsorted(old_edges, starts_stops) - 1
+    in_idx = jnp.arange(len(old_edges) - 1)
+
+    _, binned_spectrum = lax.scan(
+        lambda carry, x: body_fun(
+            carry, old_widths, old_edges, new_edges, input_flux, in_idx, x
+        ), 0, indices
+    )
+
+    return binned_spectrum
+
+
+@partial(jit, static_argnames='old_edges, new_edges, in_flux, in_idx, indices'.split(', '))
+def body_fun(i, old_widths, old_edges, new_edges, in_flux, in_idx, indices):
+    start_idx = indices[0]
+    stop_idx = indices[1]
+
+    start_factor = ((old_edges[start_idx + 1] - new_edges[i]) /
+                    (old_edges[start_idx + 1] - old_edges[start_idx]))
+
+    end_factor = ((new_edges[i + 1] - old_edges[stop_idx]) /
+                  (old_edges[stop_idx + 1] - old_edges[stop_idx]))
+
+    start_width = old_widths[start_idx] * start_factor
+    stop_width = old_widths[stop_idx] * end_factor
+
+    old_widths_weighted = jnp.where(
+        (start_idx <= in_idx) & (in_idx <= stop_idx),
+        old_widths,
+        0
+    )
+    old_widths_weighted = jnp.where(
+        in_idx == start_idx,
+        start_width,
+        old_widths_weighted
+    )
+
+    old_widths_weighted = jnp.where(
+        in_idx == stop_idx,
+        stop_width,
+        old_widths_weighted
+    )
+
+    nonzero = old_widths_weighted > 0
+    new_flux = jnp.sum(
+        old_widths_weighted * in_flux,
+        where=nonzero
+    ) / jnp.sum(
+        old_widths_weighted, where=nonzero
+    )
+
+    return i + 1, new_flux

--- a/shone/tests/test_spectrum.py
+++ b/shone/tests/test_spectrum.py
@@ -1,0 +1,34 @@
+import numpy as np
+from jax import numpy as jnp, random
+
+import astropy.units as u
+from specutils import SpectralAxis
+from specutils.manipulation import FluxConservingResampler
+
+from shone.spectrum import bin_spectrum
+
+
+def test_spectral_binning():
+    """
+    Compare our spectral binning method to the
+    specutils implementation for consistency.
+    """
+    key = random.PRNGKey(0)
+    input_wavelength = jnp.geomspace(1, 5, 5_000)
+    input_flux = 1 + 0.01 * random.normal(key, shape=input_wavelength.shape)
+    output_wavelength = jnp.geomspace(1.1, 4.9, 1_321)
+
+    shone_binned = bin_spectrum(output_wavelength, input_wavelength, input_flux)
+
+    input_spec_axis = SpectralAxis(input_wavelength * u.um)
+    output_spec_axis = SpectralAxis(output_wavelength * u.um)
+
+    fcr = FluxConservingResampler()
+    specutils_binned = fcr._fluxc_resample(
+        input_spec_axis, output_spec_axis, input_flux * u.ct, None
+    )[0].value
+
+    # check for 10 ppm agreement:
+    np.testing.assert_allclose(
+        shone_binned, specutils_binned, rtol=1e-5
+    )

--- a/shone/transmission/hk2017.py
+++ b/shone/transmission/hk2017.py
@@ -27,7 +27,7 @@ def transmission_radius_isothermal(kappa, R_0, P_0, T_0, mmw, g):
     T_0 : float
         Reference temperature [K].
     mmw : float
-        Mean molecular weight [g].
+        Mean molecular weight [AMU].
     g : float
         Surface gravity [cm/s^2], assumed to be uniform
         with height.
@@ -43,7 +43,14 @@ def transmission_radius_isothermal(kappa, R_0, P_0, T_0, mmw, g):
             <https://ui.adsabs.harvard.edu/abs/2017MNRAS.470.2972H/abstract>`_.
     """
     gamma = 0.57721  # Euler-Mascheroni constant
-    H = k_B * T_0 / (mmw * g)  # pressure scale height
+    mmw_amu = jnp.clip(mmw, 1, 100)  # [amu]
+    T_0 = jnp.clip(T_0, 100, 50_000)  # [K]
+    g = jnp.clip(g, 10, 1e10)  # [cm / s^2]
+
+    # store the ratio of the Boltzmann constant to the
+    # mass of a proton, both in cgs. Helpful for float precision:
+    k_B_over_m_p = 82543997.56725217  # [cgs]
+    H = T_0 / (mmw_amu * g) * k_B_over_m_p  # pressure scale height
 
     # Heng & Kitzmann (2017) Equation 12.
     # Only applies to isothermal atmospheres:


### PR DESCRIPTION
This PR builds on #5. It:
* adds [narrative documentation for the chemistry module](https://shone--6.org.readthedocs.build/en/6/shone/examples/chemistry.html)
* corrects an error in the assumed units for the VMR calculations
* adds a method for assembling an xarray dataset of FastChem results for a grid of temperatures, pressures, metallicities, and C/O ratios; and saves it to disk
* adds a method that returns a jitted VMR interpolator, so we can move FastChem "offline" during inference
* adds more informative error messages when files in the `~/.shone` dir have unexpected paths