### PR TITLE
Support for spectral binning in jax

### DIFF
--- a/docs/shone/api.rst
+++ b/docs/shone/api.rst
@@ -7,3 +7,5 @@ Reference/API
 .. automodapi:: shone.opacity
 
 .. automodapi:: shone.transmission
+
+.. automodapi:: shone.spectrum

--- a/shone/__init__.py
+++ b/shone/__init__.py
@@ -6,3 +6,4 @@ except ImportError:
 from .opacity import *  # noqa
 from .chemistry import *  # noqa
 from .transmission import *  # noqa
+from .spectrum import *  # noqa

--- a/shone/chemistry/fastchem.py
+++ b/shone/chemistry/fastchem.py
@@ -23,14 +23,17 @@ class FastchemWrapper:
 
     References
     ----------
-    .. [1] Stock, J. W., Kitzmann, D., Patzer, A. B. C., et al. 2018,
+    .. [1] `Stock, J. W., Kitzmann, D., Patzer, A. B. C., et al. 2018,
        Monthly Notices of the Royal Astronomical Society, 479,
-       865. doi:10.1093/mnras/sty1531
-    .. [2] Stock, J. W., Kitzmann, D., & Patzer, A. B. C. 2022,
+       865. <https://ui.adsabs.harvard.edu/abs/2018MNRAS.479..865S/abstract>`_
+       doi:10.1093/mnras/sty1531
+    .. [2] `Stock, J. W., Kitzmann, D., & Patzer, A. B. C. 2022,
        Monthly Notices of the Royal Astronomical Society, 517,
-       4070. doi:10.1093/mnras/stac2623
-    .. [3] Kitzmann, D., Stock, J. W., & Patzer, A. B. C. 2024, Monthly
+       4070. <https://ui.adsabs.harvard.edu/abs/2022MNRAS.517.4070S/abstract>`_
+       doi:10.1093/mnras/stac2623
+    .. [3] `Kitzmann, D., Stock, J. W., & Patzer, A. B. C. 2024, Monthly
        Notices of the Royal Astronomical Society, 527, 7263.
+       <https://ui.adsabs.harvard.edu/abs/2024MNRAS.527.7263K/abstract>`_
        doi:10.1093/mnras/stad3515
     .. [4] `FastChem on Github <https://github.com/exoclime/FastChem>`_.
     """

--- a/shone/opacity/dace.py
+++ b/shone/opacity/dace.py
@@ -21,7 +21,8 @@ interp_kwargs = dict(
 
 __all__ = [
     'download_molecule',
-    'download_atom'
+    'download_atom',
+    'available_opacities'
 ]
 
 
@@ -337,11 +338,13 @@ def download_molecule(
     version=None,
 ):
     """
-    Download molecular opacity data from DACE.
+    Download molecular opacity data from DACE [1]_ [2]_.
+
+    These opacities were computed with HELIOS-K [3]_ [4]_ [5]_.
 
     .. warning::
         This generates *very* large files. Only run this
-        method if you have ~6 GB available per molecule.
+        method if you a few GB available per molecule.
 
     Parameters
     ----------
@@ -363,6 +366,20 @@ def download_molecule(
     version : float, optional
         Version number of the line list in DACE. Defaults to the
         latest version.
+
+    References
+    ----------
+    .. [1] `Buchschacher, N. & Alesina, F. 2019, Astronomical Data Analysis
+           Software and Systems XXVI, 521, 757
+           <https://ui.adsabs.harvard.edu/abs/2019ASPC..521..757B/abstract>`_
+    .. [2] `DACE webpage <https://dace.unige.ch/>`_
+    .. [3] `Grimm, S. L. & Heng, K. 2015, The Astrophysical Journal, 808, 182.
+           <https://ui.adsabs.harvard.edu/abs/2015ApJ...808..182G/abstract>`_
+           doi:10.1088/0004-637X/808/2/182
+    .. [4] `Grimm, S. L., Malik, M., Kitzmann, D., et al. 2021, The Astrophysical
+           Journal Supplement Series, 253, 30. doi:10.3847/1538-4365/abd773
+           <https://ui.adsabs.harvard.edu/abs/2021ApJS..253...30G/abstract>`_
+    .. [5] `HELIOS-K on GitHub <https://github.com/exoclime/helios-k>`_
     """
     if molecule_name is not None:
         isotopologue = species_name_to_common_isotopologue_name(molecule_name)
@@ -488,11 +505,13 @@ def parse_nc_path_atom(filename):
 def download_atom(atom, charge, line_list='first-found',
                   temperature_range=None, pressure_range=None, version=None):
     """
-    Download atomic opacity data from DACE.
+    Download atomic opacity data from DACE [1]_ [2]_.
+
+    These opacities were computed with HELIOS-K [3]_ [4]_ [5]_.
 
     .. warning::
         This generates *very* large files. Only run this
-        method if you have ~6 GB available per molecule.
+        method if you have a few GB available per atom.
 
     Parameters
     ----------
@@ -514,6 +533,20 @@ def download_atom(atom, charge, line_list='first-found',
     version : float, optional
         Version number of the line list in DACE. Defaults to the
         latest version.
+
+    References
+    ----------
+    .. [1] `Buchschacher, N. & Alesina, F. 2019, Astronomical Data Analysis
+           Software and Systems XXVI, 521, 757
+           <https://ui.adsabs.harvard.edu/abs/2019ASPC..521..757B/abstract>`_
+    .. [2] `DACE webpage <https://dace.unige.ch/>`_
+    .. [3] `Grimm, S. L. & Heng, K. 2015, The Astrophysical Journal, 808, 182.
+           <https://ui.adsabs.harvard.edu/abs/2015ApJ...808..182G/abstract>`_
+           doi:10.1088/0004-637X/808/2/182
+    .. [4] `Grimm, S. L., Malik, M., Kitzmann, D., et al. 2021, The Astrophysical
+           Journal Supplement Series, 253, 30. doi:10.3847/1538-4365/abd773
+           <https://ui.adsabs.harvard.edu/abs/2021ApJS..253...30G/abstract>`_
+    .. [5] `HELIOS-K on GitHub <https://github.com/exoclime/helios-k>`_
     """
     available_line_lists = available_opacities.get_atomic_line_lists(atom)
 

--- a/shone/opacity/io.py
+++ b/shone/opacity/io.py
@@ -127,13 +127,14 @@ class Opacity:
                     temperature_range, pressure_range,
                     version
                 ) = parse_nc_path_atom(file_name)
-            else:
+            elif len(file_name.split('_')) == 7:
                 (
                     isotopologue, line_list,
                     temperature_range, pressure_range,
                     version
                 ) = parse_nc_path_molecule(file_name)
-
+            else:
+                continue
             species = isotopologue or atom
 
             table_contents["name"].append(isotopologue_to_species(species))

--- a/shone/spectrum.py
+++ b/shone/spectrum.py
@@ -38,6 +38,9 @@ def bin_spectrum(output_wavelength, input_wavelength, input_flux):
     """
     Bin a spectrum from one wavelength grid to another.
 
+    This function is a JAX implementation of SpectRes [1]_
+    from A. C. Carnall [2]_.
+
     Parameters
     ----------
     output_wavelength : array−like
@@ -51,6 +54,12 @@ def bin_spectrum(output_wavelength, input_wavelength, input_flux):
     -------
     binned_spectrum : array-like
         Spectrum binned to a different resolution.
+
+    References
+    ----------
+    .. [1] `SpectRes on GitHub <https://github.com/ACCarnall/SpectRes>`_.
+    .. [2]  Carnall, A. C. 2017, `arXiv:1705.05165 <https://arxiv.org/abs/1705.05165>`_.
+            doi:10.48550/arXiv.1705.05165
     """
     old_edges, old_widths = bin_centers_to_edges(input_wavelength)
     new_edges, new_widths = bin_centers_to_edges(output_wavelength)

--- a/shone/spectrum.py
+++ b/shone/spectrum.py
@@ -1,0 +1,110 @@
+from functools import partial
+from jax import numpy as jnp, jit, lax
+
+
+__all__ = ['bin_spectrum']
+
+
+@jit
+def bin_centers_to_edges(wavelength):
+    """
+    For a vector of bin centers, estimate the bin edges and
+    bin widths.
+
+    Parameters
+    ----------
+    wavelength : array-like
+        Wavelengths at bin centers for a spectrum.
+
+    Returns
+    -------
+    edges : array-like
+        Wavelength bin edges.
+    widths : array-like
+        Wavelength bin widths.
+    """
+    edges_0 = jnp.array([wavelength[0] - (wavelength[1] - wavelength[0]) / 2])
+    widths_m1 = jnp.array([wavelength[-1] - wavelength[-2]])
+    edges_m1 = jnp.array([wavelength[-1] + (wavelength[-1] - wavelength[-2]) / 2])
+    edges_middle = (wavelength[1:] + wavelength[:-1]) / 2
+    edges = jnp.concatenate([edges_0, edges_middle, edges_m1])
+    widths = jnp.concatenate([edges[1:-1] - edges[:-2], widths_m1])
+
+    return edges, widths
+
+
+@jit
+def bin_spectrum(output_wavelength, input_wavelength, input_flux):
+    """
+    Bin a spectrum from one wavelength grid to another.
+
+    Parameters
+    ----------
+    output_wavelength : array−like
+        The target output grid of central wavelengths.
+    input_wavelength : array-like
+        The input grid of central wavelengths.
+    input_flux : array-like
+        The fluxes at each input wavelength.
+
+    Returns
+    -------
+    binned_spectrum : array-like
+        Spectrum binned to a different resolution.
+    """
+    old_edges, old_widths = bin_centers_to_edges(input_wavelength)
+    new_edges, new_widths = bin_centers_to_edges(output_wavelength)
+
+    starts_stops = jnp.column_stack([new_edges[:-1], new_edges[1:]])
+    indices = jnp.searchsorted(old_edges, starts_stops) - 1
+    in_idx = jnp.arange(len(old_edges) - 1)
+
+    _, binned_spectrum = lax.scan(
+        lambda carry, x: body_fun(
+            carry, old_widths, old_edges, new_edges, input_flux, in_idx, x
+        ), 0, indices
+    )
+
+    return binned_spectrum
+
+
+@partial(jit, static_argnames='old_edges, new_edges, in_flux, in_idx, indices'.split(', '))
+def body_fun(i, old_widths, old_edges, new_edges, in_flux, in_idx, indices):
+    start_idx = indices[0]
+    stop_idx = indices[1]
+
+    start_factor = ((old_edges[start_idx + 1] - new_edges[i]) /
+                    (old_edges[start_idx + 1] - old_edges[start_idx]))
+
+    end_factor = ((new_edges[i + 1] - old_edges[stop_idx]) /
+                  (old_edges[stop_idx + 1] - old_edges[stop_idx]))
+
+    start_width = old_widths[start_idx] * start_factor
+    stop_width = old_widths[stop_idx] * end_factor
+
+    old_widths_weighted = jnp.where(
+        (start_idx <= in_idx) & (in_idx <= stop_idx),
+        old_widths,
+        0
+    )
+    old_widths_weighted = jnp.where(
+        in_idx == start_idx,
+        start_width,
+        old_widths_weighted
+    )
+
+    old_widths_weighted = jnp.where(
+        in_idx == stop_idx,
+        stop_width,
+        old_widths_weighted
+    )
+
+    nonzero = old_widths_weighted > 0
+    new_flux = jnp.sum(
+        old_widths_weighted * in_flux,
+        where=nonzero
+    ) / jnp.sum(
+        old_widths_weighted, where=nonzero
+    )
+
+    return i + 1, new_flux

--- a/shone/tests/test_spectrum.py
+++ b/shone/tests/test_spectrum.py
@@ -1,0 +1,34 @@
+import numpy as np
+from jax import numpy as jnp, random
+
+import astropy.units as u
+from specutils import SpectralAxis
+from specutils.manipulation import FluxConservingResampler
+
+from shone.spectrum import bin_spectrum
+
+
+def test_spectral_binning():
+    """
+    Compare our spectral binning method to the
+    specutils implementation for consistency.
+    """
+    key = random.PRNGKey(0)
+    input_wavelength = jnp.geomspace(1, 5, 5_000)
+    input_flux = 1 + 0.01 * random.normal(key, shape=input_wavelength.shape)
+    output_wavelength = jnp.geomspace(1.1, 4.9, 1_321)
+
+    shone_binned = bin_spectrum(output_wavelength, input_wavelength, input_flux)
+
+    input_spec_axis = SpectralAxis(input_wavelength * u.um)
+    output_spec_axis = SpectralAxis(output_wavelength * u.um)
+
+    fcr = FluxConservingResampler()
+    specutils_binned = fcr._fluxc_resample(
+        input_spec_axis, output_spec_axis, input_flux * u.ct, None
+    )[0].value
+
+    # check for 10 ppm agreement, excluding first and last bins:
+    np.testing.assert_allclose(
+        shone_binned, specutils_binned, rtol=1e-5
+    )

--- a/shone/tests/test_spectrum.py
+++ b/shone/tests/test_spectrum.py
@@ -28,7 +28,7 @@ def test_spectral_binning():
         input_spec_axis, output_spec_axis, input_flux * u.ct, None
     )[0].value
 
-    # check for 10 ppm agreement, excluding first and last bins:
+    # check for 10 ppm agreement:
     np.testing.assert_allclose(
         shone_binned, specutils_binned, rtol=1e-5
     )


### PR DESCRIPTION
This PR:
* implements a jittable spectral binning algorithm from [Carnall 2017](https://arxiv.org/abs/1705.05165). 
* adds a test which compares the output to an equivalent method in specutils called [FluxConservingResampler](https://specutils.readthedocs.io/en/stable/api/specutils.manipulation.FluxConservingResampler.html) to ensure our results are similar.
* adds better references to docstrings for DACE and HELIOS-K