### PR TITLE
add charge to species_name_to_fastchem_name

### DIFF
--- a/shone/chemistry/translate.py
+++ b/shone/chemistry/translate.py
@@ -62,7 +62,7 @@ def isotopologue_to_mass(isotopologue):
     return (mass if mass != 0 else getattr(elements, isotopologue).mass) * u.u
 
 
-def species_name_to_fastchem_name(species, return_mass=False):
+def species_name_to_fastchem_name(species, charge, return_mass=False):
     """
     Convert generic species name, like "H2O" or "ClAlF2", to
     Hill notation for FastChem, like "H2O1" or "Al1Cl1F2".
@@ -72,12 +72,14 @@ def species_name_to_fastchem_name(species, return_mass=False):
     Parameters
     ----------
     species : str
-        Generic name, like "H2O".
+        Generic name, like "H2O" or "Ti".
+    
+    charge: int
 
     Returns
     -------
     hill_name : str
-        Name in Hill notation, like "H2O1".
+        Name in Hill notation, like "H2O1", "Ti" or "Ti1+". "Ti1-"
     """
     atoms = np.array(list(filter(
         lambda x: len(x) > 0, re.split(r"(?<=[a-z])|(?=[A-Z])|\d", species)
@@ -97,9 +99,24 @@ def species_name_to_fastchem_name(species, return_mass=False):
 
     # If single atom, give only the name of the atom:
     if len(correct_notation) == 2 and correct_notation.endswith('1'):
+        # this means it is an atom with only 1 letter, like K, or P. 
         correct_notation = correct_notation[0]
+        # check charge and add it to the name if it is charged:
+        if charge>0:
+            correct_notation = correct_notation[0] + f'{charge}+'
+        elif charge<0:
+            correct_notation = correct_notation[0] + f'{np.abs(charge)}-'
     elif len(correct_notation) == 3 and correct_notation.endswith('1'):
+        # this means it is an atom with 2 letters, like Na, or Ti. 
+        # check charge and add it to the name if it is charged:
         correct_notation = correct_notation[:2]
+        if charge>0:
+            correct_notation = correct_notation[:2] + f'{charge}+'
+        elif charge<0:
+            correct_notation = correct_notation[:2] + f'{np.abs(charge)}-'
+
+    import pdb
+    pdb.set_trace()
 
     if return_mass:
         # Optionally return mass of species


### PR DESCRIPTION
This solves issue #12 by adding the charge to atoms where charge is bigger or smaller than 0. I included the case for negatively charged ions, not sure if it ever will be used, but we have it now anyways. 

Here is how the call has to be adopted in PR #11's example:

```fastchem_names = [
    species_name_to_fastchem_name(name, charge)
for name, charge in zip(available_species.iloc[species_indices ['name'], available_species.iloc[species_indices]['charge'])]

