### PR TITLE
Method to bin opacity in wavelength before interpolation

### DIFF
--- a/shone/chemistry/fastchem.py
+++ b/shone/chemistry/fastchem.py
@@ -394,7 +394,7 @@ def get_fastchem_interpolator(path=None):
         jnp.float32(grid.log_c_to_o.to_numpy()),
     )
 
-    @partial(jit, donate_argnames=('grid',))
+    @partial(jit, static_argnames=('grid',))
     def interp(
         temperature, pressure, log_m_to_h, log_c_to_o,
         grid=grid.to_numpy().astype(np.float32)


### PR DESCRIPTION
When computing emission spectra, we need to crop opacity grids to the wavelength, temperature, and pressure bounds of the calculation, and bin the remaining opacities in wavelength to the output wavelength grid before compiling the opacity interpolators. This PR adds a method for doing that.

Blocks #19.