### PR TITLE
Adding radial velocities

### DIFF
--- a/shone/__init__.py
+++ b/shone/__init__.py
@@ -7,3 +7,4 @@ from .chemistry import *  # noqa
 from .opacity import *  # noqa
 from .transmission import *  # noqa
 from .spectrum import *  # noqa
+from .dynamics import * # noqa

--- a/shone/constants.py
+++ b/shone/constants.py
@@ -2,7 +2,10 @@
 Astronomical constants from astropy in handy units.
 """
 import astropy.units as u
-from astropy.constants import m_p as quantity_m_p, k_B as quantity_k_B
+from astropy.constants import (m_p as quantity_m_p, k_B as quantity_k_B, G as quantity_G, 
+                               c as quantity_c, M_sun as quantity_M_sun,
+                               R_sun as quantity_R_sun
+                            )
 
 __all__ = [
     'm_p',
@@ -14,5 +17,12 @@ __all__ = [
 # constants in cgs:
 m_p = quantity_m_p.cgs.value
 k_B = quantity_k_B.cgs.value
+G = quantity_G.cgs.value
+c = quantity_c.cgs.value
+M_sun = quantity_M_sun.cgs.value
+R_sun = quantity_R_sun.cgs.value
 bar_to_dyn_cm2 = (1 * u.bar).cgs.value
 k_B_over_m_p = k_B / m_p
+d_in_seconds =  (1 * u.d).cgs.value
+au_in_cm = (1 * u.au).cgs.value
+rad_in_deg = (1 * u.rad).to('degree').value

--- a/shone/dynamics/__init__.py
+++ b/shone/dynamics/__init__.py
@@ -1,0 +1,1 @@
+from .velocities import *  # noqa

--- a/shone/dynamics/velocities.py
+++ b/shone/dynamics/velocities.py
@@ -1,0 +1,59 @@
+def v_orb(P,M,e=0,theta=0,m=0):
+    """
+    This function calculates the orbital velocity in km/s for a planet in 
+    an elliptical orbit using the vis viva quation. 
+    
+    Input is provided in terms of the orbital period and the stellar mass. 
+    Stellar mass is assumed to be known to better precision than semi-major
+    axis a. If this is not the case, you need to calculate M from a using 
+    Kepler III before proceeding with this function.
+
+    If the mass of the companion is non-negligible, then its mass can
+    also be set.
+
+
+    Parameters
+    ----------
+    P : float
+        Orbital period in days.
+
+    M : float
+        Stellar mass in solar masses.
+
+    e : float
+        eccentricity.
+
+    theta : float
+        true anomaly (radians)
+
+    m : float
+        mass of the secondary in solar masses.
+    Returns
+    -------
+    v_orb : float
+        The planet's orbital velocity in km/s.
+
+    """
+    import numpy as np
+    from jax import numpy as jnp
+    import astropy.units as u
+    import astropy.constants as const
+
+    #The vis-viva equation reads:
+    #v(r)^2 = G(M+m) (2/r - 1/a)
+
+    #r in an elliptical orbit:
+    #r(theta) = a(1-e^2) / (1+ e cos(theta))
+
+    #We need Kepler's third law to convert M's to a's or P's:
+    # a^3 / P^2 = G(M+m)/(4pi^2)
+
+    GM = const.G * (M+m)*u.M_sun
+
+    a = (GM * (P*u.d)**2 / 4 / jnp.pi**2)**(1/3)
+
+    r = a*(1-e**2) / (1+e*jnp.cos(theta))
+
+    v = (GM * ( 2/r - 1/a))**(1/2)
+
+    return(v.to('km/s').value)

--- a/shone/dynamics/velocities.py
+++ b/shone/dynamics/velocities.py
@@ -34,7 +34,6 @@ def v_orb(P,M,e=0,theta=0,m=0):
         The planet's orbital velocity in km/s.
 
     """
-    import numpy as np
     from jax import numpy as jnp
     import astropy.units as u
     import astropy.constants as const
@@ -48,12 +47,41 @@ def v_orb(P,M,e=0,theta=0,m=0):
     #We need Kepler's third law to convert M's to a's or P's:
     # a^3 / P^2 = G(M+m)/(4pi^2)
 
-    GM = const.G * (M+m)*u.M_sun
+    GM = const.G.value * (M+m)*const.M_sun.value
 
-    a = (GM * (P*u.d)**2 / 4 / jnp.pi**2)**(1/3)
+    a = (GM * (P*1*u.d.to('s'))**2 / 4 / jnp.pi**2)**(1/3)
 
     r = a*(1-e**2) / (1+e*jnp.cos(theta))
 
-    v = (GM * ( 2/r - 1/a))**(1/2)
+    v = (GM * ( 2/r - 1/a))**(1/2)  / 1000 #Convert to km/s
 
-    return(v.to('km/s').value)
+    return(v)
+
+
+
+def doppler_factor(v):
+    from jax import numpy as jnp
+    import astropy.units as u
+    import astropy.constants as const
+    """
+    This calculates the relativistic doppler factor given a 
+    radial velocity in km/s.
+
+
+    Parameters
+    ----------
+    v : float, array-like
+        Radial velocity in km/s.
+
+    Returns
+    -------
+    f : same as v
+        The doppler factor to be multiplying the wavelength with.
+
+    """
+    c =const.c.to('km/s').value
+    beta = v / c
+    f = jnp.sqrt((1+beta)/(1-beta))
+    return(f)
+
+

--- a/shone/dynamics/velocities.py
+++ b/shone/dynamics/velocities.py
@@ -1,42 +1,7 @@
 def v_orb(P,M,e=0,theta=0,m=0):
-    """
-    This function calculates the orbital velocity in km/s for a planet in 
-    an elliptical orbit using the vis viva quation. 
-    
-    Input is provided in terms of the orbital period and the stellar mass. 
-    Stellar mass is assumed to be known to better precision than semi-major
-    axis a. If this is not the case, you need to calculate M from a using 
-    Kepler III before proceeding with this function.
 
-    If the mass of the companion is non-negligible, then its mass can
-    also be set.
-
-
-    Parameters
-    ----------
-    P : float
-        Orbital period in days.
-
-    M : float
-        Stellar mass in solar masses.
-
-    e : float
-        eccentricity.
-
-    theta : float
-        true anomaly (radians)
-
-    m : float
-        mass of the secondary in solar masses.
-    Returns
-    -------
-    v_orb : float
-        The planet's orbital velocity in km/s.
-
-    """
     from jax import numpy as jnp
-    import astropy.units as u
-    import astropy.constants as const
+    from shone.constants import G,M_sun,d_in_seconds
 
     #The vis-viva equation reads:
     #v(r)^2 = G(M+m) (2/r - 1/a)
@@ -47,25 +12,22 @@ def v_orb(P,M,e=0,theta=0,m=0):
     #We need Kepler's third law to convert M's to a's or P's:
     # a^3 / P^2 = G(M+m)/(4pi^2)
 
-    GM = const.G.value * (M+m)*const.M_sun.value
+    GM = G * (M+m)*M_sun #in cgs
 
-    a = (GM * (P*1*u.d.to('s'))**2 / 4 / jnp.pi**2)**(1/3)
+    a = (GM * (P*d_in_seconds)**2 / 4 / jnp.pi**2)**(1/3) # in cm
 
-    r = a*(1-e**2) / (1+e*jnp.cos(theta))
+    r = a*(1-e**2) / (1+e*jnp.cos(theta)) # in cm
 
-    v = (GM * ( 2/r - 1/a))**(1/2)  / 1000 #Convert to km/s
+    v = (GM * ( 2/r - 1/a))**(1/2)  / 1e5 # in cm, convert to km/s
 
     return(v)
 
 
-
+from jax import jit
 def doppler_factor(v):
-    from jax import numpy as jnp
-    import astropy.units as u
-    import astropy.constants as const
     """
-    This calculates the relativistic doppler factor given a 
-    radial velocity in km/s.
+    This calculates the relativistic doppler factor given a radial velocity 
+    in km/s.
 
 
     Parameters
@@ -75,13 +37,141 @@ def doppler_factor(v):
 
     Returns
     -------
-    f : same as v
+    f : float, array-like, same as v
         The doppler factor to be multiplying the wavelength with.
 
     """
-    c =const.c.to('km/s').value
-    beta = v / c
-    f = jnp.sqrt((1+beta)/(1-beta))
+    from jax import numpy as jnp
+    from shone.constants import c
+    beta = v * 1e5 / c # c is in cgs so convert v to km/s.
+    f = jnp.sqrt((1 + beta)/(1 - beta))
     return(f)
+
+
+
+@jit
+def RV_eccentric(phase, M = 1.0, m = 0.0, P = 365.0, e = 0.0, omega = 0.0,
+                i=90.0):
+    """
+    This function calculates the radial velocity in km/s for a planet in 
+    an elliptical orbit using jaxoplanet. 
+    
+    Input is provided in terms of the orbital phases at which the radial
+    velocity is required, and the system parameters, including the 
+    stellar mass. Stellar mass is assumed to be known to better precision 
+    than the semi-major axis a. If this is not the case, you need to 
+    proceed by calculating M from a, using Kepler III.
+
+    If the mass of the companion is non-negligible, then its mass can
+    also be set.
+
+    The coordinate system follows that of the exoplanet package:
+    https://docs.exoplanet.codes/en/latest/tutorials/data-and-models/
+
+
+    Parameters
+    ----------
+    phase : float, array-like
+        Orbital phase, typically between 0 and 1.0. 0.0 is mid-transit.
+        Equivalent to the Mean Anomaly divided by 2 pi.
+
+    M : float
+        Stellar mass in solar masses.
+
+    m : float
+        Planet mass in solar masses.
+
+    P : float
+        Orbital period in days.
+
+    e : float
+        eccentricity.
+
+    omega : float
+        argument of peri-apsis, following the exoplanet package coordinate system. 
+
+    i : float
+        Orbital inclination in degrees. 90 is transiting.
+
+    Returns
+    -------
+    rv : float, array-like, same as phase
+        The planet's radial velocity in km/s.
+
+    """
+    from jaxoplanet.orbits import keplerian
+    from shone.constants import rad_in_deg, R_sun, d_in_seconds
+
+    star = keplerian.Central(mass=M, radius=1.0)
+
+    system = keplerian.System(star).add_body(mass = m, period = P, 
+                        eccentricity = e, omega_peri = omega/rad_in_deg,
+                        inclination = i/rad_in_deg,time_transit=0.0
+                        )
+
+    planet = system.bodies[0]
+
+    vz = planet.velocity(phase * P)[2] # along the z axis in Rsol per day.
+
+    # Convert to km/s, note that the positive z axis is the negative RV axis.
+    rv = vz * R_sun / 1e5 / d_in_seconds * -1 
+   
+    return(rv)
+
+@jit
+def RV_circular(phase, M = 1.0, m = 0.0, P = 365.0, i=90.0):
+    """
+    This function calculates the radial velocity in km/s for a planet in 
+    a circular orbit using standard analytical mechanics, in an attempt
+    to be faster than jaxoplanet. 
+    
+    Input is provided in terms of the orbital phases at which the radial
+    velocity is required, and the system parameters, including the 
+    stellar mass. Stellar mass is assumed to be known to better precision 
+    than the semi-major axis a. If this is not the case, you need to 
+    proceed by calculating M from a, using Kepler III.
+
+    If the mass of the companion is non-negligible, then its mass can
+    also be set.
+
+
+
+    Parameters
+    ----------
+    phase : float, array-like
+        Orbital phase, typically between 0 and 1.0. 0.0 is mid-transit. 
+        Equivalent to the Mean Anomaly divided by 2 pi.
+
+    M : float
+        Stellar mass in solar masses.
+
+    m : float
+        Planet mass in solar masses.
+
+    P : float
+        Orbital period in days.
+
+    i : float
+        Orbital inclination in degrees. 90 is transiting.
+
+    Returns
+    -------
+    rv : float, array-like
+        The planet's radial velocity in km/s.
+
+    """
+    from jax import numpy as jnp
+    import numpy as np
+    from shone.constants import G,M_sun,d_in_seconds,rad_in_deg
+
+    GM = G * (M+m)*M_sun #in cgs
+    a = (GM * (P*d_in_seconds)**2 / 4 / jnp.pi**2)**(1/3) # in cm
+
+    v_orb = jnp.sqrt(GM / a) # in cgs
+
+    rv = v_orb * jnp.sin(phase * 2 * np.pi) * jnp.sin(i/rad_in_deg) # in cgs
+    return(rv / 1e5) # Convert to km/s.
+
+ 
 
 


### PR DESCRIPTION
This small PR adds functions that allow, given the parameters of an exoplanet system, to compute the radial velocity of the planet against an array of orbital phases. This uses jaxoplanet to solve for eccentric orbits. 

It also implements the relativistic doppler factor that will be needed to doppler-shift our spectra to these radial velocities.

It also expands the constants namespace to do the required unit conversions.


