### PR TITLE
Update pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,8 +16,7 @@ authors = [
   { name = "Brett M. Morris, Jens Hoeijmakers", email = "morrisbrettm@gmail.com" },
 ]
 dependencies = [
-    "jax[cpu]<=0.4.29",
-    "jaxlib<=0.4.29",
+    "jax[cpu]",
     "jaxoplanet",
     "specutils",
     "periodictable",


### PR DESCRIPTION
Currently fails with
```
AttributeError: jax.interpreters.xla.pytype_aval_mappings was deprecated in JAX v0.5.0 and removed in JAX v0.7.0. jax.core.pytype_aval_mappings can be used as a replacement in most cases.
```
in `tensorflow_probability`.